### PR TITLE
Add hashbang to default package script

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -84,7 +84,8 @@
                   nativeBuildInputs = [ pkgs.sox ];
                 } ''
                 mkdir -p $out/bin
-                echo ${pkgs.sox}/bin/play ${song} >$out/bin/song
+                echo "#!${pkgs.bash}/bin/bash" >> $out/bin/song
+                echo ${pkgs.sox}/bin/play ${song} >> $out/bin/song
                 chmod +x $out/bin/song
               '';
           };


### PR DESCRIPTION
Apparently not having a hashbang breaks this on nix 2.20.